### PR TITLE
Allow user to select which element sets to include in export

### DIFF
--- a/CSVExportPlugin.php
+++ b/CSVExportPlugin.php
@@ -41,7 +41,7 @@ class CSVExportPlugin extends Omeka_Plugin_AbstractPlugin
   {
     $settings = unserialize(get_option('csv_export_settings'));
     $table = get_db()->getTable('ElementSet');
-    $elementSetsAll = $table->fetchObjects($table->getSelect()->where('record_type <> "File"')->orWhere('record_type IS NULL'));
+    $elementSetsAll = $table->fetchObjects($table->getSelect());
     include 'config-form.php';
   }
 

--- a/CSVExportPlugin.php
+++ b/CSVExportPlugin.php
@@ -4,50 +4,89 @@
 class CSVExportPlugin extends Omeka_Plugin_AbstractPlugin
 {
 
-	//Add filters
-    protected $_filters = array(
-        'admin_navigation_main'
+  //Add filters
+  protected $_filters = array(
+    'admin_navigation_main'
+  );
+
+  // Define Hooks
+  protected $_hooks = array(
+    'install',
+    'uninstall',
+    'config_form',
+    'config',
+    'admin_items_browse'
+
+  );
+
+  public function hookInstall()
+  {
+    $table = get_db()->getTable('ElementSet');
+    $dublinCore = $table->findByName('Dublin Core');
+    $defaults = array(
+      'elementSets' => array(),
     );
+    if (isset($dublinCore->id)) {
+      $defaults['elementSets'][$dublinCore->id] = TRUE;
+    }
+    set_option('csv_export_settings', serialize($defaults));
+  }
 
-	// Define Hooks
-    protected $_hooks = array(
-        'admin_items_browse'
-        
+  public function hookUninstall()
+  {
+    delete_option('csv_export_settings');
+  }
+
+  public function hookConfigForm()
+  {
+    $settings = unserialize(get_option('csv_export_settings'));
+    $table = get_db()->getTable('ElementSet');
+    $elementSetsAll = $table->fetchObjects($table->getSelect()->where('record_type <> "File"')->orWhere('record_type IS NULL'));
+    include 'config-form.php';
+  }
+
+  public function hookConfig()
+  {
+    $settings = unserialize(get_option('csv_export_settings'));
+    $elementSets = $_POST['elementSets'];
+    $settings['elementSets'] = array();
+    foreach ($elementSets as $id => $checked) {
+      if (is_numeric($id) && (bool) $checked) {
+        $settings['elementSets'][(int) $id] = (bool) $checked;
+      }
+    }
+    set_option('csv_export_settings', serialize($settings));
+  }
+
+  public function filterAdminNavigationMain($nav)
+  {
+
+    $nav[] = array(
+      'label' => __('CSV Export'),
+      'uri' => url('/csv-export/index')
     );
+    return $nav;
+  }
 
+  // Adds a button to the admin search page for CSV export
+  public function hookAdminItemsBrowse($items)
+  {
+    if (isset($_GET['search']) && count($items)) {
+      $params = array();
+      foreach ($_GET as $key => $value) {
+        $params[$key] = $value;
+      }
+      try {
+        $params['hits'] = ZEND_REGISTRY::get('total_results');
+      } catch (Zend_Exception $e) {
+        $params['hits'] = 0;
+      }
+      echo "<a  class='button blue' style='margin-top:20px;' href='" . url('csv-export/export/csv', $params) . "'><input style='background-color:transparent;color:white;border:none;' type='button' value='Export results as CSV' /></a>";
+    } else {
+      echo "<a class='button blue' style='margin-top:20px;' href='" . url('csv-export/export/csv') . "'><input style='background-color:transparent;color:white;border:none;' type='button' value='Export all data as CSV' /></a>";
+    }
+  }
 
-
-	public function filterAdminNavigationMain($nav)
-	{
-
-	    $nav[] = array(
-	                    'label' => __('CSV Export'),
-	                    'uri' => url('/csv-export/index')
-	                  );
-	    return $nav;
-	}
-
-	// Adds a button to the admin search page for CSV export
-	public function hookAdminItemsBrowse($items)
-	{
-		if (isset($_GET['search']) && count($items))
-		{
-			$params = array();
-			foreach ($_GET as $key => $value){
-					$params[$key] = $value;
-			}
-			try{
-					$params['hits'] = ZEND_REGISTRY::get('total_results');
-			}
-			catch(Zend_Exception $e){
-					$params['hits'] = 0;
-			}
-			echo "<a  class='button blue' style='margin-top:20px;' href='" . url('csv-export/export/csv', $params) ."'><input style='background-color:transparent;color:white;border:none;' type='button' value='Export results as CSV' /></a>";
-		} else {
-			echo "<a class='button blue' style='margin-top:20px;' href='" . url('csv-export/export/csv') ."'><input style='background-color:transparent;color:white;border:none;' type='button' value='Export all data as CSV' /></a>";
-		}
-	}
-	
 }
 
 ?>

--- a/config-form.php
+++ b/config-form.php
@@ -1,0 +1,20 @@
+<?php $view = get_view(); ?>
+<div id="csv-export-settings">
+<h2><?php echo __('Element Sets to include'); ?></h2>
+
+    <div class="field">
+        <div class="inputs five columns omega">
+            <p class="explanation">
+                <?php echo __('Check the box below to include a given element set in exports.'); ?>
+            </p>
+            <ul class="checkboxes">
+                <?php foreach($elementSetsAll as $elementSet):?>
+                  <li style="list-style-type: none">
+                    <?php echo $view->formCheckbox("elementSets[{$elementSet->id}]", null, array('checked' => array_key_exists($elementSet->id, $settings['elementSets']))); ?>
+                    <?php echo __($elementSet->name); ?>
+                  </li>
+            <?php endforeach; ?>
+            </ul>
+        </div>
+    </div>
+</div>

--- a/controllers/ExportController.php
+++ b/controllers/ExportController.php
@@ -2,94 +2,92 @@
 
 class CSVExport_ExportController extends Omeka_Controller_AbstractActionController
 {
-	
-    public function csvAction()
-    {
-    	$search = false;
 
-	if (isset($_GET['search'])){
-		$items = $this->csv_search($_GET);
-		$search = true;
-	} else {
-		$items = get_records('Item', array(), 0);
-	}
-	
-	// manually identify specific fields for output
-	 //$elements = array();
-	/* $elements[] = get_db()->getTable('Element')->findByElementSetNameAndElementName('Dublin Core','Title');
-	 $elements[]= get_db()->getTable('Element')->findByElementSetNameAndElementName('Dublin Core','Type');
-	 $elements[]= get_db()->getTable('Element')->findByElementSetNameAndElementName('Dublin Core','Date');
-	 $elements[]= get_db()->getTable('Element')->findByElementSetNameAndElementName('Dublin Core','Creator');*/
-	
-	
-	// get all fields from a specific element set (eg. dublin core)
-         $elementSetName = 'Dublin Core';
-         $elements = get_db()->getTable('Element')->findBySet($elementSetName);
-    	
-    	// get all fields from all element sets
-    	/*$table = get_db()->getTable('Element');
-    	
-    	
-        $select = $table->getSelect()
-            ->order('elements.element_set_id')
-            ->order('ISNULL(elements.order)')
-            ->order('elements.order');
-        $elements = $table->fetchObjects($select);*/
-		
-	set_loop_records('items', $items);
-	foreach(loop('items') as $item){
-	
-		// get omeka id and add it to the csv output
-		$id = metadata($item, 'ID');		
-		$result[$id]['id'] = $id;
-		
-		// get collection name and add it to the csv output
-		$result[$id]['Collection Name'] = metadata($item, 'collection name');
-		
-		foreach ($elements as $element){
-			// remove Omeka Legacy File metadata from csv output
-			if ($element->getElementSet()->record_type != 'File') {
-				$elementSet = $element->getElementSet()->name;
-				$element = $element->name;
-				$result[$id][$element] = metadata($item, array($elementSet, $element), array('all'=>true));
-				if (count($result[$id][$element]) == 1){
-				// the field has 1 value, get it
-					$result[$id][$element] = $result[$id][$element][0];
-				} elseif (count($result[$id][$element])>1) {
-				// if a field has multiple values, parse them
-					$results ='';
-					foreach ($result[$id][$element] as $value){
-						$results .= $value. '; ';
-					}
-					$result[$id][$element] = rtrim($results, "; ");
-				
-				} else {
-				// this field is empty/null
-					$result[$id][$element] = null;
-				}
-			}
-		}
-			    
-	}
-			
-	$this->view->assign('result', $result);
-	$this->view->assign('search', $search);
-		
+  public function csvAction()
+  {
+    $search = false;
+
+    if (isset($_GET['search'])) {
+      $items = $this->csv_search($_GET);
+      $search = true;
+    } else {
+      $items = get_records('Item', array(), 0);
     }
-	
-    function csv_search($terms) {   
-        $itemTable = $this->_helper->db->getTable('Item');
-        if (isset($_GET['search'])) {           
-            $items = $itemTable->findBy($_GET);   
-            return $items;                   
+
+    // Get all element sets except for legacy files data.
+    $table = get_db()->getTable('ElementSet');
+    $elementSetsAll = $table->fetchObjects($table->getSelect()->where('record_type <> "File"')->orWhere('record_type IS NULL'));
+    $elementSets = array();
+
+    // Filter by those set in config UI.
+    $settings = unserialize(get_option('csv_export_settings'));
+    foreach ($elementSetsAll as $elementSet) {
+      if (array_key_exists($elementSet->id, $settings['elementSets'])) {
+        $elementSets[$elementSet->id] = $elementSet;
+      }
+    }
+
+    // get all fields from a specific element set (eg. dublin core)
+    $elements = array();
+    foreach ($elementSets as $elementSet) {
+      $elements = array_merge(
+        $elements,
+        get_db()->getTable('Element')->findBySet($elementSet->name)
+      );
+    }
+
+    set_loop_records('items', $items);
+    foreach (loop('items') as $item) {
+
+      // get omeka id and add it to the csv output
+      $id = metadata($item, 'ID');
+      $result[$id]['id'] = $id;
+
+      // get collection name and add it to the csv output
+      $result[$id]['Collection Name'] = metadata($item, 'collection name');
+
+      // Cache element set info to speed up loop.
+      foreach ($elements as $element) {
+        $elementSetName = $elementSets[$element->element_set_id]->name;
+        $element = $element->name;
+        $result[$id][$element] = metadata($item, array($elementSetName, $element), array('all' => true));
+        if (count($result[$id][$element]) == 1) {
+          // the field has 1 value, get it
+          $result[$id][$element] = $result[$id][$element][0];
+        } elseif (count($result[$id][$element]) > 1) {
+          // if a field has multiple values, parse them
+          $results = '';
+          foreach ($result[$id][$element] as $value) {
+            $results .= $value . '; ';
+          }
+          $result[$id][$element] = rtrim($results, "; ");
+
         } else {
-            $queryArray = unserialize($itemTable->query);
-            // Some parts of the advanced search check $_GET, others check
-            // $_REQUEST, so we set both to be able to edit a previous query.
-            $_GET = $queryArray;
-            $_REQUEST = $queryArray;
-            $items = $itemTable->findBy($_REQUEST);   
-            return $items;
+          // this field is empty/null
+          $result[$id][$element] = null;
         }
+      }
     }
+
+    $this->view->assign('result', $result);
+    $this->view->assign('search', $search);
+
+  }
+
+  function csv_search($terms)
+  {
+    $itemTable = $this->_helper->db->getTable('Item');
+    if (isset($_GET['search'])) {
+      $items = $itemTable->findBy($_GET);
+      return $items;
+    } else {
+      $queryArray = unserialize($itemTable->query);
+      // Some parts of the advanced search check $_GET, others check
+      // $_REQUEST, so we set both to be able to edit a previous query.
+      $_GET = $queryArray;
+      $_REQUEST = $queryArray;
+      $items = $itemTable->findBy($_REQUEST);
+      return $items;
+    }
+  }
 }

--- a/controllers/ExportController.php
+++ b/controllers/ExportController.php
@@ -16,7 +16,7 @@ class CSVExport_ExportController extends Omeka_Controller_AbstractActionControll
 
     // Get all element sets except for legacy files data.
     $table = get_db()->getTable('ElementSet');
-    $elementSetsAll = $table->fetchObjects($table->getSelect()->where('record_type <> "File"')->orWhere('record_type IS NULL'));
+    $elementSetsAll = $table->fetchObjects($table->getSelect());
     $elementSets = array();
 
     // Filter by those set in config UI.


### PR DESCRIPTION
Hi @adehner! This is an awesome plugin thanks so much for coding it :stars:

I wanted to add the ability on our site to export all metadata if need be, so I added a config form with checkboxes for each element set so they can be toggled on and off. The default behavior is to export Dublin Core, just like the plugin currently does, but then users can add additional element sets if desired.

This PR also reformats the code in the two PHP files I touched so that they have consistent indentation & spacing (so it looks like a lot of the code is changed but really there are only a few changes).

Look forward to hearing your thoughts!!